### PR TITLE
Interpreteractions

### DIFF
--- a/test.mkr
+++ b/test.mkr
@@ -1,0 +1,2 @@
+# Comment!
+id = (\x.x)


### PR DESCRIPTION
Splits actions in "Interpreter actions" and "Actions". The interpreter can do things like load a file or exit that are not real actions on the language.